### PR TITLE
mercury now builds all three profiles without a make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,18 @@ endif
 
 
 # implicit rules
+compile-profile = \
+  $(strip \
+    $(if $(filter %.c,$<), \
+      $(compiler) $(cflags) $(flags) $(profflags) $1 -c $< -o $@, \
+      $(if $(filter %.cpp,$<), \
+        $(compiler) $(cppflags) $(flags) $(profflags) $1 -c $< -o $@ \
+      ) \
+    ) \
+  )
+
+%-$(profile).o: $<; $(call compile-profile)
+
 compile = \
   $(strip \
     $(if $(filter %.c,$<), \

--- a/sfc/Makefile
+++ b/sfc/Makefile
@@ -14,19 +14,19 @@ sfc_objects += sfc-hlecx4 sfc-hlest0010
 sfc_objects += sfc-sgbexternal
 
 ifeq ($(profile),accuracy)
-  flags += -DPROFILE_ACCURACY
+  profflags := -DPROFILE_ACCURACY
   sfccpu := $(sfc)/cpu
   sfcsmp := $(sfc)/smp
   sfcdsp := $(sfc)/dsp
   sfcppu := $(sfc)/ppu
 else ifeq ($(profile),balanced)
-  flags += -DPROFILE_BALANCED
+  profflags := -DPROFILE_BALANCED
   sfccpu := $(sfc)/cpu
   sfcsmp := $(sfc)/smp
   sfcdsp := $(sfc)/alt/dsp
   sfcppu := $(sfc)/alt/ppu-balanced
 else ifeq ($(profile),performance)
-  flags += -DPROFILE_PERFORMANCE
+  profflags := -DPROFILE_PERFORMANCE
   sfccpu := $(sfc)/alt/cpu
   sfcsmp := $(sfc)/alt/smp
   sfcdsp := $(sfc)/alt/dsp

--- a/sfc/Makefile
+++ b/sfc/Makefile
@@ -12,7 +12,6 @@ sfc_objects += sfc-satellaviewcart sfc-sufamiturbo
 sfc_objects += sfc-hledsp1 sfc-hledsp2 sfc-hledsp3 sfc-hledsp4
 sfc_objects += sfc-hlecx4 sfc-hlest0010
 sfc_objects += sfc-sgbexternal
-objects += $(sfc_objects)
 
 ifeq ($(profile),accuracy)
   flags += -DPROFILE_ACCURACY
@@ -36,50 +35,50 @@ else
   $(error unknown profile.)
 endif
 
-obj/sfc-interface.o:       $(sfc)/interface/interface.cpp $(call rwildcard,$(sfc)/interface)
-obj/sfc-system.o:          $(sfc)/system/system.cpp $(call rwildcard,$(sfc)/system/)
-obj/sfc-controller.o:      $(sfc)/controller/controller.cpp $(call rwildcard,$(sfc)/controller/)
-obj/sfc-cartridge.o:       $(sfc)/cartridge/cartridge.cpp $(sfc)/cartridge/*
-obj/sfc-cheat.o:           $(sfc)/cheat/cheat.cpp $(sfc)/cheat/*
-obj/sfc-memory.o:          $(sfc)/memory/memory.cpp $(call rwildcard,$(sfc)/memory/)
-obj/sfc-cpu.o:             $(sfccpu)/cpu.cpp $(call rwildcard,$(sfccpu)/)
-obj/sfc-smp.o:             $(sfcsmp)/smp.cpp $(call rwildcard,$(sfcsmp)/)
-obj/sfc-dsp.o:             $(sfcdsp)/dsp.cpp $(call rwildcard,$(sfcdsp)/)
-obj/sfc-ppu.o:             $(sfcppu)/ppu.cpp $(call rwildcard,$(sfcppu)/)
+obj/sfc-interface-$(profile).o:       $(sfc)/interface/interface.cpp $(call rwildcard,$(sfc)/interface)
+obj/sfc-system-$(profile).o:          $(sfc)/system/system.cpp $(call rwildcard,$(sfc)/system/)
+obj/sfc-controller-$(profile).o:      $(sfc)/controller/controller.cpp $(call rwildcard,$(sfc)/controller/)
+obj/sfc-cartridge-$(profile).o:       $(sfc)/cartridge/cartridge.cpp $(sfc)/cartridge/*
+obj/sfc-cheat-$(profile).o:           $(sfc)/cheat/cheat.cpp $(sfc)/cheat/*
+obj/sfc-memory-$(profile).o:          $(sfc)/memory/memory.cpp $(call rwildcard,$(sfc)/memory/)
+obj/sfc-cpu-$(profile).o:             $(sfccpu)/cpu.cpp $(call rwildcard,$(sfccpu)/)
+obj/sfc-smp-$(profile).o:             $(sfcsmp)/smp.cpp $(call rwildcard,$(sfcsmp)/)
+obj/sfc-dsp-$(profile).o:             $(sfcdsp)/dsp.cpp $(call rwildcard,$(sfcdsp)/)
+obj/sfc-ppu-$(profile).o:             $(sfcppu)/ppu.cpp $(call rwildcard,$(sfcppu)/)
 
-obj/sfc-satellaviewbase.o: $(sfc)/base/satellaview/satellaview.cpp $(call rwildcard,$(sfc)/base/satellaview/)
+obj/sfc-satellaviewbase-$(profile).o: $(sfc)/base/satellaview/satellaview.cpp $(call rwildcard,$(sfc)/base/satellaview/)
 
-obj/sfc-icd2.o:            $(sfc)/chip/icd2/icd2.cpp $(call rwildcard,$(sfc)/chip/icd2/)
-obj/sfc-bsx.o:             $(sfc)/chip/bsx/bsx.cpp $(call rwildcard,$(sfc)/chip/bsx/)
-obj/sfc-nss.o:             $(sfc)/chip/nss/nss.cpp $(call rwildcard,$(sfc)/chip/nss/)
-obj/sfc-event.o:           $(sfc)/chip/event/event.cpp $(call rwildcard,$(sfc)/chip/event/)
+obj/sfc-icd2-$(profile).o:            $(sfc)/chip/icd2/icd2.cpp $(call rwildcard,$(sfc)/chip/icd2/)
+obj/sfc-bsx-$(profile).o:             $(sfc)/chip/bsx/bsx.cpp $(call rwildcard,$(sfc)/chip/bsx/)
+obj/sfc-nss-$(profile).o:             $(sfc)/chip/nss/nss.cpp $(call rwildcard,$(sfc)/chip/nss/)
+obj/sfc-event-$(profile).o:           $(sfc)/chip/event/event.cpp $(call rwildcard,$(sfc)/chip/event/)
 
-obj/sfc-sa1.o:             $(sfc)/chip/sa1/sa1.cpp $(call rwildcard,$(sfc)/chip/sa1/)
-obj/sfc-superfx.o:         $(sfc)/chip/superfx/superfx.cpp $(call rwildcard,$(sfc)/chip/superfx/)
+obj/sfc-sa1-$(profile).o:             $(sfc)/chip/sa1/sa1.cpp $(call rwildcard,$(sfc)/chip/sa1/)
+obj/sfc-superfx-$(profile).o:         $(sfc)/chip/superfx/superfx.cpp $(call rwildcard,$(sfc)/chip/superfx/)
 
-obj/sfc-armdsp.o:          $(sfc)/chip/armdsp/armdsp.cpp $(call rwildcard,$(sfc)/chip/armdsp/)
-obj/sfc-hitachidsp.o:      $(sfc)/chip/hitachidsp/hitachidsp.cpp $(call rwildcard,$(sfc)/chip/hitachidsp/)
-obj/sfc-necdsp.o:          $(sfc)/chip/necdsp/necdsp.cpp $(call rwildcard,$(sfc)/chip/necdsp/)
+obj/sfc-armdsp-$(profile).o:          $(sfc)/chip/armdsp/armdsp.cpp $(call rwildcard,$(sfc)/chip/armdsp/)
+obj/sfc-hitachidsp-$(profile).o:      $(sfc)/chip/hitachidsp/hitachidsp.cpp $(call rwildcard,$(sfc)/chip/hitachidsp/)
+obj/sfc-necdsp-$(profile).o:          $(sfc)/chip/necdsp/necdsp.cpp $(call rwildcard,$(sfc)/chip/necdsp/)
 
-obj/sfc-epsonrtc.o:        $(sfc)/chip/epsonrtc/epsonrtc.cpp $(call rwildcard,$(sfc)/chip/epsonrtc/)
-obj/sfc-sharprtc.o:        $(sfc)/chip/sharprtc/sharprtc.cpp $(call rwildcard,$(sfc)/chip/sharprtc/)
+obj/sfc-epsonrtc-$(profile).o:        $(sfc)/chip/epsonrtc/epsonrtc.cpp $(call rwildcard,$(sfc)/chip/epsonrtc/)
+obj/sfc-sharprtc-$(profile).o:        $(sfc)/chip/sharprtc/sharprtc.cpp $(call rwildcard,$(sfc)/chip/sharprtc/)
 
-obj/sfc-spc7110.o:         $(sfc)/chip/spc7110/spc7110.cpp $(sfc)/chip/spc7110/*
-obj/sfc-sdd1.o:            $(sfc)/chip/sdd1/sdd1.cpp $(sfc)/chip/sdd1/*
-obj/sfc-obc1.o:            $(sfc)/chip/obc1/obc1.cpp $(sfc)/chip/obc1/*
+obj/sfc-spc7110-$(profile).o:         $(sfc)/chip/spc7110/spc7110.cpp $(sfc)/chip/spc7110/*
+obj/sfc-sdd1-$(profile).o:            $(sfc)/chip/sdd1/sdd1.cpp $(sfc)/chip/sdd1/*
+obj/sfc-obc1-$(profile).o:            $(sfc)/chip/obc1/obc1.cpp $(sfc)/chip/obc1/*
 
-obj/sfc-hsu1.o:            $(sfc)/chip/hsu1/hsu1.cpp $(sfc)/chip/hsu1/*
-obj/sfc-msu1.o:            $(sfc)/chip/msu1/msu1.cpp $(sfc)/chip/msu1/*
+obj/sfc-hsu1-$(profile).o:            $(sfc)/chip/hsu1/hsu1.cpp $(sfc)/chip/hsu1/*
+obj/sfc-msu1-$(profile).o:            $(sfc)/chip/msu1/msu1.cpp $(sfc)/chip/msu1/*
 
-obj/sfc-satellaviewcart.o: $(sfc)/slot/satellaview/satellaview.cpp $(call rwildcard,$(sfc)/slot/satellaview/)
-obj/sfc-sufamiturbo.o:     $(sfc)/slot/sufamiturbo/sufamiturbo.cpp $(call rwildcard,$(sfc)/slot/sufamiturbo/)
+obj/sfc-satellaviewcart-$(profile).o: $(sfc)/slot/satellaview/satellaview.cpp $(call rwildcard,$(sfc)/slot/satellaview/)
+obj/sfc-sufamiturbo-$(profile).o:     $(sfc)/slot/sufamiturbo/sufamiturbo.cpp $(call rwildcard,$(sfc)/slot/sufamiturbo/)
 
-obj/sfc-hledsp1.o:         $(sfc)/chip/dsp1/dsp1.cpp $(sfc)/chip/dsp1/*
-obj/sfc-hledsp2.o:         $(sfc)/chip/dsp2/dsp2.cpp $(sfc)/chip/dsp2/*
-obj/sfc-hledsp3.o:         $(sfc)/chip/dsp3/dsp3.cpp $(sfc)/chip/dsp3/*
-obj/sfc-hledsp4.o:         $(sfc)/chip/dsp4/dsp4.cpp $(sfc)/chip/dsp4/*
+obj/sfc-hledsp1-$(profile).o:         $(sfc)/chip/dsp1/dsp1.cpp $(sfc)/chip/dsp1/*
+obj/sfc-hledsp2-$(profile).o:         $(sfc)/chip/dsp2/dsp2.cpp $(sfc)/chip/dsp2/*
+obj/sfc-hledsp3-$(profile).o:         $(sfc)/chip/dsp3/dsp3.cpp $(sfc)/chip/dsp3/*
+obj/sfc-hledsp4-$(profile).o:         $(sfc)/chip/dsp4/dsp4.cpp $(sfc)/chip/dsp4/*
 
-obj/sfc-hlecx4.o:          $(sfc)/chip/cx4/cx4.cpp $(sfc)/chip/cx4/*
-obj/sfc-hlest0010.o:       $(sfc)/chip/st0010/st0010.cpp $(sfc)/chip/st0010/*
+obj/sfc-hlecx4-$(profile).o:          $(sfc)/chip/cx4/cx4.cpp $(sfc)/chip/cx4/*
+obj/sfc-hlest0010-$(profile).o:       $(sfc)/chip/st0010/st0010.cpp $(sfc)/chip/st0010/*
 
-obj/sfc-sgbexternal.o:     $(sfc)/chip/sgb-external/sgb-external.cpp $(sfc)/chip/sgb-external/*
+obj/sfc-sgbexternal-$(profile).o:     $(sfc)/chip/sgb-external/sgb-external.cpp $(sfc)/chip/sgb-external/*

--- a/target-ethos/Makefile
+++ b/target-ethos/Makefile
@@ -43,6 +43,8 @@ link += $(rubylink)
 # rules
 objects := $(ui_objects) $(objects)
 objects := $(patsubst %,obj/%.o,$(objects))
+sfc_objects := $(patsubst %,obj/%-$(profile).o,$(sfc_objects))
+objects += $(sfc_objects)
 
 obj/ui-ethos.o: $(ui)/ethos.cpp $(call rwildcard,$(ui)/)
 obj/ui-configuration.o: $(ui)/configuration/configuration.cpp $(call rwildcard,$(ui)/)

--- a/target-libretro/Makefile
+++ b/target-libretro/Makefile
@@ -31,48 +31,50 @@ flags += -D__LIBRETRO__
 #rules
 objects += libretro
 objects := $(patsubst %,obj/%.o,$(objects))
+sfc_objects := $(patsubst %,obj/%-$(profile).o,$(sfc_objects))
+objects += $(sfc_objects)
 
 obj/libretro.o: $(ui)/libretro.cpp $(ui)/*
 
 #targets
 build: $(objects)
 ifeq ($(platform),linux)
-	$(compiler) -o out/bsnes_mercury_libretro.so -shared $(objects) -ldl -Wl,--no-undefined -Wl,--version-script=$(ui)/link.T $(link)
+	$(compiler) -o out/bsnes_mercury_$(profile)_libretro.so -shared $(objects) -ldl -Wl,--no-undefined -Wl,--version-script=$(ui)/link.T $(link)
 else ifeq ($(platform),bsd)
-	$(compiler) -o out/bsnes_mercury_libretro.so -shared $(objects) -ldl -Wl,--no-undefined -Wl,--version-script=$(ui)/link.T $(link)
+	$(compiler) -o out/bsnes_mercury_$(profile)_libretro.so -shared $(objects) -ldl -Wl,--no-undefined -Wl,--version-script=$(ui)/link.T $(link)
 else ifeq ($(platform),ios)
-	$(compiler) -o out/bsnes_mercury_libretro_ios.dylib -dynamiclib $(objects) -isysroot $(IOSSDK) -arch armv7 $(link)
+	$(compiler) -o out/bsnes_mercury_$(profile)_libretro_ios.dylib -dynamiclib $(objects) -isysroot $(IOSSDK) -arch armv7 $(link)
 else ifeq ($(platform),macosx)
 ifdef ($(NOUNIVERSAL))
-	$(compiler) -o out/bsnes_mercury_libretro.dylib -dynamiclib $(objects) $(link)
+	$(compiler) -o out/bsnes_mercury_$(profile)_libretro.dylib -dynamiclib $(objects) $(link)
 else
-	$(compiler) $(ARCHFLAGS) -o out/bsnes_mercury_libretro.dylib -dynamiclib $(objects) $(link)
+	$(compiler) $(ARCHFLAGS) -o out/bsnes_mercury_$(profile)_libretro.dylib -dynamiclib $(objects) $(link)
 endif
 else ifeq ($(platform),windows)
-	$(compiler) -o out/bsnes_mercury_libretro.dll -shared $(objects) -Wl,--no-undefined -Wl,--version-script=$(ui)/link.T -static-libgcc -static-libstdc++ -lws2_32 $(link)
+	$(compiler) -o out/bsnes_mercury_$(profile)_libretro.dll -shared $(objects) -Wl,--no-undefined -Wl,--version-script=$(ui)/link.T -static-libgcc -static-libstdc++ -lws2_32 $(link)
 else
 	$(error invalid platform: $(platform). valid platforms are: windows linux macosx ios bsd)
 endif
 
 install:
 ifeq ($(platform),linux)
-	install -D -m 755 out/bsnes_mercury_libretro.so $(DESTDIR)$(prefix)/lib/bsnes_mercury_libretro.so
+	install -D -m 755 out/bsnes_mercury_$(profile)_libretro.so $(DESTDIR)$(prefix)/lib/bsnes_mercury_$(profile)_libretro.so
 else ifeq ($(platform),bsd)
-	install -D -m 755 out/bsnes_mercury_libretro.so $(DESTDIR)$(prefix)/lib/bsnes_mercury_libretro.so
+	install -D -m 755 out/bsnes_mercury_$(profile)_libretro.so $(DESTDIR)$(prefix)/lib/bsnes_mercury_$(profile)_libretro.so
 else ifeq ($(platform),macosx)
-	cp out/bsnes_mercury_libretro.dylib $(DESTDIR)$(prefix)/lib/bsnes_mercury_libretro.dylib
+	cp out/bsnes_mercury_$(profile)_libretro.dylib $(DESTDIR)$(prefix)/lib/bsnes_mercury_$(profile)_libretro.dylib
 else ifeq ($(platform),ios)
-	cp out/bsnes_mercury_libretro_ios.dylib $(DESTDIR)$(prefix)/lib/bsnes_mercury_libretro_ios.dylib
+	cp out/bsnes_mercury_$(profile)_libretro_ios.dylib $(DESTDIR)$(prefix)/lib/bsnes_mercury_$(profile)_libretro_ios.dylib
 endif
 
 uninstall:
 ifeq ($(platform),linux)
-	rm $(DESTDIR)$(prefix)/lib/bsnes_mercury_libretro.so
+	rm $(DESTDIR)$(prefix)/lib/bsnes_mercury_$(profile)_libretro.so
 else ifeq ($(platform),bsd)
-	rm $(DESTDIR)$(prefix)/lib/bsnes_mercury_libretro.so
+	rm $(DESTDIR)$(prefix)/lib/bsnes_mercury_$(profile)_libretro.so
 else ifeq ($(platform),macosx)
-	rm /usr/local/lib/bsnes_mercury_libretro.dylib
+	rm /usr/local/lib/bsnes_mercury_$(profile)_libretro.dylib
 else ifeq ($(platform),ios)
-	rm /usr/local/lib/bsnes_mercury_libretro_ios.dylib
+	rm /usr/local/lib/bsnes_mercury_$(profile)_libretro_ios.dylib
 endif
 

--- a/target-libretro/Makefile
+++ b/target-libretro/Makefile
@@ -29,12 +29,12 @@ endif
 flags += -D__LIBRETRO__
 
 #rules
-objects += libretro
 objects := $(patsubst %,obj/%.o,$(objects))
+sfc_objects += libretro
 sfc_objects := $(patsubst %,obj/%-$(profile).o,$(sfc_objects))
 objects += $(sfc_objects)
 
-obj/libretro.o: $(ui)/libretro.cpp $(ui)/*
+obj/libretro-$(profile).o: $(ui)/libretro.cpp $(ui)/*
 
 #targets
 build: $(objects)


### PR DESCRIPTION
Same as what I did in libretro-bsnes, complete with the renaming of the output files.  This change needs to be merged along with the PR for libretro-super which knows about the change.