### PR TITLE
Trigger frame event on NMI, with trigger on vcounter() == 241 as fallback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ gba := gba
 profile := accuracy
 target  := libretro
 
+# SFC input lag fix
+sfc_lagfix := 1
+
 # options += debugger
 # arch := x86
 # console := true

--- a/sfc/Makefile
+++ b/sfc/Makefile
@@ -35,6 +35,10 @@ else
   $(error unknown profile.)
 endif
 
+ifeq ($(sfc_lagfix),1)
+	flags += -DSFC_LAGFIX
+endif
+
 obj/sfc-interface-$(profile).o:       $(sfc)/interface/interface.cpp $(call rwildcard,$(sfc)/interface)
 obj/sfc-system-$(profile).o:          $(sfc)/system/system.cpp $(call rwildcard,$(sfc)/system/)
 obj/sfc-controller-$(profile).o:      $(sfc)/controller/controller.cpp $(call rwildcard,$(sfc)/controller/)

--- a/sfc/alt/cpu/cpu.cpp
+++ b/sfc/alt/cpu/cpu.cpp
@@ -138,6 +138,8 @@ void CPU::reset() {
   status.nmi_line = false;
   status.nmi_transition = false;
   status.nmi_pending = false;
+  
+  status.frame_event_performed = false;
 
   status.irq_valid = false;
   status.irq_line = false;

--- a/sfc/alt/cpu/cpu.cpp
+++ b/sfc/alt/cpu/cpu.cpp
@@ -139,7 +139,9 @@ void CPU::reset() {
   status.nmi_transition = false;
   status.nmi_pending = false;
   
+#ifdef SFC_LAGFIX
   status.frame_event_performed = false;
+#endif
 
   status.irq_valid = false;
   status.irq_line = false;

--- a/sfc/alt/cpu/cpu.hpp
+++ b/sfc/alt/cpu/cpu.hpp
@@ -106,6 +106,8 @@ private:
     bool nmi_line;
     bool nmi_transition;
     bool nmi_pending;
+    
+    bool frame_event_performed;
 
     bool irq_valid;
     bool irq_line;

--- a/sfc/alt/cpu/cpu.hpp
+++ b/sfc/alt/cpu/cpu.hpp
@@ -107,7 +107,9 @@ private:
     bool nmi_transition;
     bool nmi_pending;
     
+#ifdef SFC_LAGFIX
     bool frame_event_performed;
+#endif
 
     bool irq_valid;
     bool irq_line;

--- a/sfc/alt/cpu/serialization.cpp
+++ b/sfc/alt/cpu/serialization.cpp
@@ -41,7 +41,9 @@ void CPU::serialize(serializer& s) {
   s.integer(status.nmi_transition);
   s.integer(status.nmi_pending);
   
+#ifdef SFC_LAGFIX
   s.integer(status.frame_event_performed);
+#endif
 
   s.integer(status.irq_valid);
   s.integer(status.irq_line);

--- a/sfc/alt/cpu/serialization.cpp
+++ b/sfc/alt/cpu/serialization.cpp
@@ -40,6 +40,8 @@ void CPU::serialize(serializer& s) {
   s.integer(status.nmi_line);
   s.integer(status.nmi_transition);
   s.integer(status.nmi_pending);
+  
+  s.integer(status.frame_event_performed);
 
   s.integer(status.irq_valid);
   s.integer(status.irq_line);

--- a/sfc/alt/cpu/timing.cpp
+++ b/sfc/alt/cpu/timing.cpp
@@ -17,8 +17,10 @@ void CPU::last_cycle() {
     regs.wai = false;
     status.nmi_transition = false;
     status.nmi_pending = true;
+#ifdef SFC_LAGFIX
     scheduler.exit(Scheduler::ExitReason::FrameEvent);
     status.frame_event_performed = true;
+#endif
   }
 
   if(status.irq_transition || regs.irq) {
@@ -64,11 +66,17 @@ void CPU::scanline() {
   synchronize_smp();
   synchronize_ppu();
   synchronize_coprocessors();
-  system.scanline(&status.frame_event_performed);
+#ifdef SFC_LAGFIX
+  system.scanline(status.frame_event_performed);
+#else
+  system.scanline();
+#endif
 
   if(vcounter() == 0)
   {
+#ifdef SFC_LAGFIX
     status.frame_event_performed = false;
+#endif
     hdma_init();
   }
 

--- a/sfc/cpu/cpu.hpp
+++ b/sfc/cpu/cpu.hpp
@@ -57,7 +57,9 @@ privileged:
     bool nmi_pending;
     bool nmi_hold;
     
+#ifdef SFC_LAGFIX
     bool frame_event_performed;
+#endif
 
     bool irq_valid;
     bool irq_line;

--- a/sfc/cpu/cpu.hpp
+++ b/sfc/cpu/cpu.hpp
@@ -56,6 +56,8 @@ privileged:
     bool nmi_transition;
     bool nmi_pending;
     bool nmi_hold;
+    
+    bool frame_event_performed;
 
     bool irq_valid;
     bool irq_line;

--- a/sfc/cpu/serialization.cpp
+++ b/sfc/cpu/serialization.cpp
@@ -31,7 +31,9 @@ void CPU::serialize(serializer& s) {
   s.integer(status.nmi_pending);
   s.integer(status.nmi_hold);
   
+#ifdef SFC_LAGFIX
   s.integer(status.frame_event_performed);
+#endif
 
   s.integer(status.irq_valid);
   s.integer(status.irq_line);

--- a/sfc/cpu/serialization.cpp
+++ b/sfc/cpu/serialization.cpp
@@ -30,6 +30,8 @@ void CPU::serialize(serializer& s) {
   s.integer(status.nmi_transition);
   s.integer(status.nmi_pending);
   s.integer(status.nmi_hold);
+  
+  s.integer(status.frame_event_performed);
 
   s.integer(status.irq_valid);
   s.integer(status.irq_line);

--- a/sfc/cpu/timing/irq.cpp
+++ b/sfc/cpu/timing/irq.cpp
@@ -12,8 +12,10 @@ void CPU::poll_interrupts() {
     if(status.nmi_enabled)
     {
       status.nmi_transition = true;
+#ifdef SFC_LAGFIX
       scheduler.exit(Scheduler::ExitReason::FrameEvent);
       status.frame_event_performed = true;
+#endif
     }
   }
 
@@ -62,8 +64,10 @@ void CPU::nmitimen_update(uint8 data) {
   //0->1 edge sensitive transition
   if(!nmi_enabled && status.nmi_enabled && status.nmi_line) {
     status.nmi_transition = true;
+#ifdef SFC_LAGFIX
     scheduler.exit(Scheduler::ExitReason::FrameEvent);
     status.frame_event_performed = true;
+#endif
   }
 
   //?->1 level sensitive transition

--- a/sfc/cpu/timing/irq.cpp
+++ b/sfc/cpu/timing/irq.cpp
@@ -9,7 +9,12 @@ void CPU::poll_interrupts() {
   //NMI hold
   if(status.nmi_hold) {
     status.nmi_hold = false;
-    if(status.nmi_enabled) status.nmi_transition = true;
+    if(status.nmi_enabled)
+    {
+      status.nmi_transition = true;
+      scheduler.exit(Scheduler::ExitReason::FrameEvent);
+      status.frame_event_performed = true;
+    }
   }
 
   //NMI test
@@ -57,6 +62,8 @@ void CPU::nmitimen_update(uint8 data) {
   //0->1 edge sensitive transition
   if(!nmi_enabled && status.nmi_enabled && status.nmi_line) {
     status.nmi_transition = true;
+    scheduler.exit(Scheduler::ExitReason::FrameEvent);
+    status.frame_event_performed = true;
   }
 
   //?->1 level sensitive transition

--- a/sfc/cpu/timing/timing.cpp
+++ b/sfc/cpu/timing/timing.cpp
@@ -46,9 +46,11 @@ void CPU::scanline() {
   synchronize_smp();
   synchronize_ppu();
   synchronize_coprocessors();
-  system.scanline();
+  system.scanline(&status.frame_event_performed);
 
   if(vcounter() == 0) {
+    status.frame_event_performed = false;
+    
     //HDMA init triggers once every frame
     status.hdma_init_position = (cpu_version == 1 ? 12 + 8 - dma_counter() : 12 + dma_counter());
     status.hdma_init_triggered = false;
@@ -181,6 +183,8 @@ void CPU::timing_reset() {
   status.nmi_transition = false;
   status.nmi_pending    = false;
   status.nmi_hold       = false;
+  
+  status.frame_event_performed = false;
 
   status.irq_valid      = false;
   status.irq_line       = false;

--- a/sfc/cpu/timing/timing.cpp
+++ b/sfc/cpu/timing/timing.cpp
@@ -46,10 +46,16 @@ void CPU::scanline() {
   synchronize_smp();
   synchronize_ppu();
   synchronize_coprocessors();
-  system.scanline(&status.frame_event_performed);
+#ifdef SFC_LAGFIX
+  system.scanline(status.frame_event_performed);
+#else
+  system.scanline();
+#endif
 
   if(vcounter() == 0) {
+#ifdef SFC_LAGFIX
     status.frame_event_performed = false;
+#endif
     
     //HDMA init triggers once every frame
     status.hdma_init_position = (cpu_version == 1 ? 12 + 8 - dma_counter() : 12 + dma_counter());
@@ -184,7 +190,9 @@ void CPU::timing_reset() {
   status.nmi_pending    = false;
   status.nmi_hold       = false;
   
+#ifdef SFC_LAGFIX
   status.frame_event_performed = false;
+#endif
 
   status.irq_valid      = false;
   status.irq_line       = false;

--- a/sfc/system/system.cpp
+++ b/sfc/system/system.cpp
@@ -280,12 +280,17 @@ void System::reset() {
   input.connect(1, configuration.controller_port2);
 }
 
-void System::scanline(bool * frame_event_performed) {
+void System::scanline() {
+  bool frame_event_performed = false;
+  scanline(frame_event_performed);
+}
+
+void System::scanline(bool& frame_event_performed) {
   video.scanline();
-  if(!(*frame_event_performed) && cpu.vcounter() == 241)
+  if(cpu.vcounter() == 241 && !frame_event_performed)
   {
     scheduler.exit(Scheduler::ExitReason::FrameEvent);
-    *frame_event_performed = true;
+    frame_event_performed = true;
   }
 }
 

--- a/sfc/system/system.cpp
+++ b/sfc/system/system.cpp
@@ -280,9 +280,13 @@ void System::reset() {
   input.connect(1, configuration.controller_port2);
 }
 
-void System::scanline() {
+void System::scanline(bool * frame_event_performed) {
   video.scanline();
-  if(cpu.vcounter() == 241) scheduler.exit(Scheduler::ExitReason::FrameEvent);
+  if(!(*frame_event_performed) && cpu.vcounter() == 241)
+  {
+    scheduler.exit(Scheduler::ExitReason::FrameEvent);
+    *frame_event_performed = true;
+  }
 }
 
 void System::frame() {

--- a/sfc/system/system.hpp
+++ b/sfc/system/system.hpp
@@ -15,7 +15,8 @@ struct System : property<System> {
   void reset();
 
   void frame();
-  void scanline(bool * frame_event_performed);
+  void scanline(bool& frame_event_performed);
+  void scanline();
 
   //return *active* system information (settings are cached upon power-on)
   readonly<Region> region;

--- a/sfc/system/system.hpp
+++ b/sfc/system/system.hpp
@@ -15,7 +15,7 @@ struct System : property<System> {
   void reset();
 
   void frame();
-  void scanline();
+  void scanline(bool * frame_event_performed);
 
   //return *active* system information (settings are cached upon power-on)
   readonly<Region> region;


### PR DESCRIPTION
This is a fix that removes one full frame of input lag. There is already a pull request for a similar fix, but that fix was thought to have side effects in certain corner cases (enabling overscan mid-frame). See old pull request here:

https://github.com/libretro/bsnes-mercury/pull/17

This new code relies on the fact that the NMI (non-maskable interrupt) triggers right at the beginning of the VBLANK period. By exiting the emulator loop with a frame event right when the emulator raises NMI, we're able to exit before the input is read, thereby shaving off one frame of input lag.

The neat thing about this version of the fix is that it should work with games that modify the overscan bit mid-frame. Waiting for NMI should be reliable, since this is what game code itself does to detect when a frame has been rendered and when it's safe to run the game code. Please refer to the following link, section "SETINI - Screen Mode/Video Select" for overscan/NMI info:

http://wiki.superfamicom.org/snes/show/Registers

As you can see, the overscan bit's value directly affects when NMI occurs, which further strengthens the argument to use it as a frame event trigger.

As a safeguard, the original condition of exiting the emulator loop and reporting a frame event at V=241 is still there. If, for some reason, an NMI hasn't occurred when V=241, the behavior will be exactly the same as it is today.

**A note regarding bsnes-mercury vs higan v099:**

While comparing the source code of bsnes-mercury with the latest version of higan, I noticed some important discrepancies. While higan correctly detects overscan changes mid-frame by reading the register value directly, bsnes-mercury does not (at least not in all places). bsnes-mercury instead calls the PPU:overscan() function, which returns a value that was cached at the beginning of the frame. Example from /sfc/cpu/timing/irq.cpp:

**bsnes-mercury:**
`bool nmi_valid = (vcounter(2) >= (!ppu.overscan() ? 225 : 240));`

**higan v099**
`bool nmi_valid = vcounter(2) >= ppu.vdisp(); //Brunnis: vdisp() returns !regs.overscan ? 225 : 240`

Given this inaccuracy in bsnes-mercury regarding overscan handling, it would probably be okay to merge the original pull request. However, the new fix is better, since it doesn't have _any_ direct dependence on the overscan value.