### PR TITLE
Add mingw platform as was defaulting to del instead of rm in MSYS2

### DIFF
--- a/nall/Makefile
+++ b/nall/Makefile
@@ -21,7 +21,7 @@ ifeq ($(platform),)
   else ifneq ($(findstring CYGWIN,$(uname)),)
     platform := windows
   else ifneq ($(findstring MINGW,$(uname)),)
-    platform := windows
+    platform := mingw
   else ifneq ($(findstring Darwin,$(uname)),)
     platform := macosx
   else ifneq ($(findstring BSD,$(uname)),)
@@ -33,6 +33,9 @@ endif
 
 ifeq ($(platform),windows)
   delete = del /F /Q $(subst /,\,$1)
+else ifeq ($(platform),mingw)
+  delete = rm -f $1
+  platform := windows
 else
   delete = rm -f $1
 endif


### PR DESCRIPTION
make clean was trying to use del instead of rm under MSYS2 so I've added "mingw" as a valid platform and made it use rm, defaulting back to platform := windows again afterwards.