### PR TITLE
Overscan and aspect ratio core options

### DIFF
--- a/target-libretro/libretro.cpp
+++ b/target-libretro/libretro.cpp
@@ -581,6 +581,7 @@ static void update_variables(void) {
 
    struct retro_variable var;
    struct retro_system_av_info av_info;
+   bool geometry_update = false;
 
    if (SuperFamicom::cartridge.has_superfx()) {
       const char * speed=read_opt("bsnes_superfx_overclock", "100%");
@@ -590,26 +591,28 @@ static void update_variables(void) {
 
    var.key = "bsnes_overscan";
 
-   if (core_bind.penviron(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
+   if (core_bind.penviron(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) {
       if (!strcmp(var.value, "enabled"))
          core_bind.overscan = false;
       else
          core_bind.overscan = true;
+      geometry_update = true;
    }
 
    var.key = "bsnes_aspect";
 
-   if (core_bind.penviron(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
+   if (core_bind.penviron(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) {
       if (!strcmp(var.value, "8:7 PAR"))
          core_bind.use_par = true;
       else
          core_bind.use_par = false;
+      geometry_update = true;
    }
 
-   retro_get_system_av_info(&av_info);
-   core_bind.penviron(RETRO_ENVIRONMENT_SET_GEOMETRY, &av_info);
+   if (geometry_update) {
+      retro_get_system_av_info(&av_info);
+      core_bind.penviron(RETRO_ENVIRONMENT_SET_GEOMETRY, &av_info);
+   }
 }
 
 void retro_set_video_refresh(retro_video_refresh_t cb)           { core_bind.pvideo_refresh = cb; }

--- a/target-libretro/libretro.cpp
+++ b/target-libretro/libretro.cpp
@@ -594,7 +594,7 @@ static void update_variables(void) {
    {
       if (!strcmp(var.value, "enabled"))
          core_bind.overscan = false;
-      else if(!strcmp(var.value, "disabled"))
+      else
          core_bind.overscan = true;
    }
 
@@ -604,7 +604,7 @@ static void update_variables(void) {
    {
       if (!strcmp(var.value, "8:7 PAR"))
          core_bind.use_par = true;
-      else if(!strcmp(var.value, "4:3"))
+      else
          core_bind.use_par = false;
    }
 

--- a/target-libretro/libretro.cpp
+++ b/target-libretro/libretro.cpp
@@ -592,21 +592,23 @@ static void update_variables(void) {
    var.key = "bsnes_overscan";
 
    if (core_bind.penviron(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) {
-      if (!strcmp(var.value, "enabled"))
-         core_bind.overscan = false;
-      else
-         core_bind.overscan = true;
-      geometry_update = true;
+      bool newval = (!strcmp(var.value, "disabled"));
+      if (newval != core_bind.overscan)
+      {
+        core_bind.overscan = newval;
+        geometry_update = true;
+      }
    }
 
    var.key = "bsnes_aspect";
 
    if (core_bind.penviron(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) {
-      if (!strcmp(var.value, "8:7 PAR"))
-         core_bind.use_par = true;
-      else
-         core_bind.use_par = false;
-      geometry_update = true;
+      bool newval = (!strcmp(var.value, "8:7 PAR"));
+      if (newval != core_bind.use_par)
+      {
+        core_bind.use_par = newval;
+        geometry_update = true;
+      }
    }
 
    if (geometry_update) {


### PR DESCRIPTION
Overscan is controlled by core option now instead of RETRO_ENVIRONMENT_GET_OVERSCAN.

Core reported aspect ratio can now be set to 8:7 PAR (like in higan) or 4:3 DAR.

Also, update geometry when options are changed.
