### PR TITLE
Fix lagfix regression which makes multiple frame events possible within a single VBLANK interval

### DIFF
--- a/sfc/alt/cpu/timing.cpp
+++ b/sfc/alt/cpu/timing.cpp
@@ -74,7 +74,14 @@ void CPU::scanline() {
   system.scanline();
 #endif
 
-  if(vcounter() == 0) hdma_init();
+  if(vcounter() == 0)
+  {
+#ifdef SFC_LAGFIX
+    status.frame_event_performed = false;
+#endif
+    
+    hdma_init();
+  }
 
   queue.enqueue(534, QueueEvent::DramRefresh);
 

--- a/sfc/cpu/timing/timing.cpp
+++ b/sfc/cpu/timing/timing.cpp
@@ -53,6 +53,10 @@ void CPU::scanline() {
 #endif
 
   if(vcounter() == 0) {
+#ifdef SFC_LAGFIX
+    status.frame_event_performed = false;
+#endif
+    
     //HDMA init triggers once every frame
     status.hdma_init_position = (cpu_version == 1 ? 12 + 8 - dma_counter() : 12 + dma_counter());
     status.hdma_init_triggered = false;

--- a/sfc/system/system.cpp
+++ b/sfc/system/system.cpp
@@ -291,7 +291,7 @@ void System::scanline(bool& frame_event_performed) {
     if(!frame_event_performed) {
       scheduler.exit(Scheduler::ExitReason::FrameEvent);
     }
-    frame_event_performed = false;
+    frame_event_performed = true;
   }
 }
 


### PR DESCRIPTION
_Note: This is copied from the corresponding pull request for the bsnes-libretro core (https://github.com/libretro/bsnes-libretro/pull/19):_

This pull request fixes an issue observed in Alien vs Predator, where the screen would stretch out horizontally seconds after you start moving in the first level. See this thread for details:

http://libretro.com/forums/showthread.php?t=6728

It was observed that the issue only occurred with the lagfix enabled. After analyzing the code it seems this bug was introduced while investigating the MSU-1 issue reported here: #14

It was found that the lagfix didn't cause those MSU-1 issues, but the code changes that were made to the lagfix were kept, since they were considered an improvement. The issue with these code changes appears to be the following:

The frame_event_performed flag is cleared already at V=241. When this happens, there are still several lines left of the VBLANK interval. If a game enables NMI (or disables and re-enables NMI) after line 241 but before the end of VBLANK, another frame event will occur. This appears to be what Alien vs Predator does.

Therefore, it's crucial that the frame_event_performed flag isn't cleared until after the VBLANK interval ends and before the next one starts, i.e. somewhere between V=0 and V=224. The initial pull request for the lagfix did actually clear the flag on V=0. However, this was not considered safe, according to comment nr 5 in this pull request: #14. The comment mentions that clearing the flag in the CPU's scanline() function is bad because the screen might be off which will cause the function to not be called when V=0 and therefore the frame_event_performed flag won't clear. Is this actually true? I'd appreciate a second look at this, but to me it looks like the CPU's scanline() function will in fact always be called when V=0.

If I'm wrong, I'd appreciate your opinions on alternate points in the code where it would be safe to clear the frame_event_performed flag. Otherwise, I propose that we change back to clearing the flag in the CPU's scanline() function as this pull request suggests.