### PR TITLE
Change when frame_event_performed flag is cleared

### DIFF
--- a/sfc/alt/cpu/timing.cpp
+++ b/sfc/alt/cpu/timing.cpp
@@ -70,12 +70,7 @@ void CPU::scanline() {
   synchronize_coprocessors();
   system.scanline(status.frame_event_performed);
 
-  if(vcounter() == 0)
-  {
-    status.frame_event_performed = false;
-
-    hdma_init();
-  }
+  if(vcounter() == 0) hdma_init();
 
   queue.enqueue(534, QueueEvent::DramRefresh);
 
@@ -90,6 +85,7 @@ void CPU::scanline() {
     if(status.nmi_enabled) status.nmi_transition = true;
   } else if(nmi_valid && !status.nmi_valid) {
     status.nmi_line = false;
+    status.frame_event_performed = false;
   }
 
   if(status.auto_joypad_poll_enabled && vcounter() == (ppu.overscan() == false ? 227 : 242)) {

--- a/sfc/cpu/timing/irq.cpp
+++ b/sfc/cpu/timing/irq.cpp
@@ -30,6 +30,7 @@ void CPU::poll_interrupts() {
   } else if(status.nmi_valid && !nmi_valid) {
     //1->0 edge sensitive transition
     status.nmi_line = false;
+    status.frame_event_performed = false;
   }
   status.nmi_valid = nmi_valid;
 

--- a/sfc/cpu/timing/timing.cpp
+++ b/sfc/cpu/timing/timing.cpp
@@ -49,8 +49,6 @@ void CPU::scanline() {
   system.scanline(status.frame_event_performed);
 
   if(vcounter() == 0) {
-    status.frame_event_performed = false;
-    
     //HDMA init triggers once every frame
     status.hdma_init_position = (cpu_version == 1 ? 12 + 8 - dma_counter() : 12 + dma_counter());
     status.hdma_init_triggered = false;


### PR DESCRIPTION
Moved the clearing of the frame_event_performed flag from sfc/cpu/timing/timing.cpp to sfc/cpu/timing/irq.cpp, so that it occurs at exactly the same place as where the nmi_valid signal goes from high to low. This is only a slight change from previously, where the flag was cleared in scanline() when vcounter()==0. The change may not have any practical effects, but it does make more sense, since the old code actually clears the flag just before the nmi_valid signal goes low.

I've made the corresponding change to sfc/alt/cpu/timing.cpp as well, even though it's actually not needed there (the interrupt code executes inside scanline() without any delay anyway). I made this change just to make sure that the code for the two CPU variants mimic each other as closely as possible (easier to read/understand).