### PR TITLE
Make setting DEBUG like other libretro cores

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ sfc_lagfix := 1
 
 # compiler
 
-ifneq ($(debug),)
+ifeq ($(DEBUG), 1)
   flags := -I. -O0 -g
 else
   flags := -I. -O3 -fomit-frame-pointer


### PR DESCRIPTION
Most of the libretro cores check if `DEBUG=1` is set while the bsnes cores check if `debug` is set. This PR will change the bsnes-mercury Makefile to be more like the other cores as being able to set `DEBUG=0` or `DEBUG=1` can be useful.