### PR TITLE
Report git version with library_version

### DIFF
--- a/target-libretro/Makefile
+++ b/target-libretro/Makefile
@@ -28,6 +28,11 @@ endif
 
 flags += -D__LIBRETRO__
 
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	flags += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
+
 #rules
 objects := $(patsubst %,obj/%.o,$(objects))
 sfc_objects += libretro

--- a/target-libretro/jni/Android.mk
+++ b/target-libretro/jni/Android.mk
@@ -2,6 +2,11 @@ LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
 
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	LOCAL_CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
+
 ifeq ($(TARGET_ARCH),arm)
   LOCAL_CFLAGS += -DANDROID_ARM
   LOCAL_ARM_MODE := arm

--- a/target-libretro/libretro.cpp
+++ b/target-libretro/libretro.cpp
@@ -675,7 +675,10 @@ void retro_cheat_set(unsigned index, bool enable, const char *code) {
 }
 
 void retro_get_system_info(struct retro_system_info *info) {
-  static string version("v", Emulator::Version, " (", Emulator::Profile, ")");
+#ifndef GIT_VERSION
+#define GIT_VERSION ""
+#endif
+  static string version("v", Emulator::Version, " (", Emulator::Profile, ")", GIT_VERSION);
   info->library_name     = "bsnes-mercury";
   info->library_version  = version;
   info->valid_extensions = "sfc|smc|bml";


### PR DESCRIPTION
This patch makes this core report the git version along with its library_version. This is important because otherwise it is impossible to replicate a build without extra knowledge, and things like Netplay that demand versions be the same can't be reliably known to work.