### PR TITLE
Allow setting GIT_VERSION

### DIFF
--- a/target-libretro/Makefile
+++ b/target-libretro/Makefile
@@ -28,7 +28,7 @@ endif
 
 flags += -D__LIBRETRO__
 
-GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+GIT_VERSION ?= " $(shell git rev-parse --short HEAD || echo unknown)"
 ifneq ($(GIT_VERSION)," unknown")
 	flags += -DGIT_VERSION=\"$(GIT_VERSION)\"
 endif

--- a/target-libretro/jni/Android.mk
+++ b/target-libretro/jni/Android.mk
@@ -2,7 +2,7 @@ LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
 
-GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+GIT_VERSION ?= " $(shell git rev-parse --short HEAD || echo unknown)"
 ifneq ($(GIT_VERSION)," unknown")
 	LOCAL_CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
 endif


### PR DESCRIPTION
Same idea behind. https://github.com/libretro/bsnes-libretro/pull/28

If `.git` is missing an easy to avoid error is printed.