### PR TITLE
SDD1 backport.

### DIFF
--- a/sfc/chip/sdd1/sdd1.cpp
+++ b/sfc/chip/sdd1/sdd1.cpp
@@ -50,6 +50,8 @@ uint8 SDD1::read(unsigned addr) {
   }
 
   switch(addr) {
+  case 0x4800: return sdd1_enable;
+  case 0x4801: return xfer_enable;
   case 0x4804: return mmc[0] >> 20;
   case 0x4805: return mmc[1] >> 20;
   case 0x4806: return mmc[2] >> 20;


### PR DESCRIPTION
This fix is courtesy of @bparker06 .

This fixes https://github.com/libretro/bsnes-mercury/issues/34.