### PR TITLE
Silence more -Wparentheses warnings

### DIFF
--- a/sfc/chip/cx4/cx4.cpp
+++ b/sfc/chip/cx4/cx4.cpp
@@ -196,7 +196,7 @@ uint16 Cx4::readw(uint16 addr) {
 }
 
 uint32 Cx4::readl(uint16 addr) {
-  return read(addr) | (read(addr + 1) << 8) + (read(addr + 2) << 16);
+  return read(addr) | ((read(addr + 1) << 8) + (read(addr + 2) << 16));
 }
 
 void Cx4::power() {

--- a/sfc/chip/spc7110/decompressor.cpp
+++ b/sfc/chip/spc7110/decompressor.cpp
@@ -14,7 +14,7 @@ struct Decompressor {
   //inverse morton code transform: unpack big-endian packed pixels
   //returns odd bits in lower half; even bits in upper half
   uint32 deinterleave(uint64 data, unsigned bits) {
-    data = data & (1ull << bits) - 1;
+    data = data & ((1ull << bits) - 1);
     data = 0x5555555555555555ull & (data << bits | data >> 1);
     data = 0x3333333333333333ull & (data | data >> 1);
     data = 0x0f0f0f0f0f0f0f0full & (data | data >> 2);
@@ -72,7 +72,7 @@ struct Decompressor {
 
       for(unsigned plane = 0; plane < bpp; plane++) {
         unsigned bit = bpp > 1 ? 1 << plane : 1 << (pixel & 3);
-        unsigned history = bit - 1 & output;
+        unsigned history = (bit - 1) & output;
         unsigned set = 0;
 
         if(bpp == 1) set = pixel >= 4;
@@ -108,7 +108,7 @@ struct Decompressor {
         if(symbol == LPS && model.probability > Half) ctx.swap ^= 1;
       }
 
-      unsigned index = output & (1 << bpp) - 1;
+      unsigned index = output & ((1 << bpp) - 1);
       if(bpp == 1) index ^= pixels >> 15 & 1;
 
       pixels = pixels << bpp | (map >> 4 * index & 15);


### PR DESCRIPTION
If compiled with `-Wall` this will silence the following `-Wparentheses` warnings.
```
In file included from sfc/chip/spc7110/dcu.cpp:1:0,
                 from sfc/chip/spc7110/spc7110.cpp:6:
sfc/chip/spc7110/decompressor.cpp: In member function ‘uint32 SuperFamicom::Decompressor::deinterleave(uint64, unsigned int)’:
sfc/chip/spc7110/decompressor.cpp:17:34: warning: suggest parentheses around ‘-’ in operand of ‘&’ [-Wparentheses]
     data = data & (1ull << bits) - 1;
                                  ^
sfc/chip/spc7110/decompressor.cpp: In member function ‘void SuperFamicom::Decompressor::decode()’:
sfc/chip/spc7110/decompressor.cpp:75:32: warning: suggest parentheses around ‘-’ in operand of ‘&’ [-Wparentheses]
         unsigned history = bit - 1 & output;
                                ^
sfc/chip/spc7110/decompressor.cpp:111:44: warning: suggest parentheses around ‘-’ in operand of ‘&’ [-Wparentheses]
       unsigned index = output & (1 << bpp) - 1;
                                            ^
sfc/chip/cx4/cx4.cpp: In member function ‘uint32 SuperFamicom::Cx4::readl(uint16)’:
sfc/chip/cx4/cx4.cpp:199:45: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]
   return read(addr) | (read(addr + 1) << 8) + (read(addr + 2) << 16);
```