### PR TITLE
Remove unused variable

### DIFF
--- a/nall/string/char/compare.hpp
+++ b/nall/string/char/compare.hpp
@@ -28,7 +28,7 @@ int istrcmp(const char* str1, const char* str2) {
 
 bool strbegin(const char* str, const char* key) {
   if(!str || !key) return false;
-  int i, ssl = strlen(str), ksl = strlen(key);
+  int ssl = strlen(str), ksl = strlen(key);
 
   if(ksl > ssl) return false;
   return (!memcmp(str, key, ksl));


### PR DESCRIPTION
If compiled with `-Wall` this silences a `-Wunused-variable` warning which is spammed.
```
In file included from ./nall/string/char.hpp:4:0,
                 from ./nall/string.hpp:27,
                 from ./nall/base64.hpp:5,
                 from ./emulator/emulator.hpp:22,
                 from ./processor/processor.hpp:4,
                 from processor/arm/arm.cpp:1:
./nall/string/char/compare.hpp: In function ‘bool nall::strbegin(const char*, const char*)’:
./nall/string/char/compare.hpp:31:7: warning: unused variable ‘i’ [-Wunused-variable]
   int i, ssl = strlen(str), ksl = strlen(key);
       ^
```