### PR TITLE
Remove another unused variable

### DIFF
--- a/nall/base64.hpp
+++ b/nall/base64.hpp
@@ -74,7 +74,7 @@ string Base64::encode(const string& text, Format format) {
 vector<uint8_t> Base64::decode(const string& text) {
   vector<uint8_t> result;
 
-  uint8_t buffer, output;
+  uint8_t output;
   for(unsigned i = 0; i < text.size(); i++) {
     uint8_t buffer = value(text[i]);
     if(buffer == 0) break;

--- a/nall/png.hpp
+++ b/nall/png.hpp
@@ -76,7 +76,6 @@ bool png::decode(const uint8_t* sourceData, unsigned sourceSize) {
   while(offset < sourceSize) {
     unsigned length   = read(sourceData + offset + 0, 4);
     unsigned fourCC   = read(sourceData + offset + 4, 4);
-    unsigned checksum = read(sourceData + offset + 8 + length, 4);
 
     if(fourCC == (unsigned)FourCC::IHDR) {
       info.width             = read(sourceData + offset +  8, 4);


### PR DESCRIPTION
Silences another spammed `-Wunused-variable` warning if compiled with `-Wall`.
```
In file included from ./emulator/emulator.hpp:22:0,
                 from ./sfc/sfc.hpp:4,
                 from sfc/chip/st0010/st0010.cpp:1:
./nall/base64.hpp: In static member function ‘static nall::vector<unsigned char> nall::Base64::decode(const nall::string&)’:
./nall/base64.hpp:77:11: warning: unused variable ‘buffer’ [-Wunused-variable]
   uint8_t buffer, output;
```