### PR TITLE
Silence a -Wreturn-type warning

### DIFF
--- a/target-libretro/libretro.cpp
+++ b/target-libretro/libretro.cpp
@@ -379,6 +379,7 @@ struct Callbacks : Emulator::Interface::Bind {
     if (video_fmt == video_fmt_32) return (r << 16) | (g << 8) | (b << 0);
     if (video_fmt == video_fmt_16) return (r>>3 << 11) | (g>>2 << 5) | (b>>3 << 0);
     if (video_fmt == video_fmt_15) return (r>>3 << 10) | (g>>3 << 5) | (b>>3 << 0);
+    return 0;
   }
 
   void notify(string text) {


### PR DESCRIPTION
Silences a `-Wreturn-type` warning with `-Wall`.
```
target-libretro/libretro.cpp: In member function ‘virtual uint32_t Callbacks::videoColor(unsigned int, uint16_t, uint16_t, uint16_t, uint16_t)’:
target-libretro/libretro.cpp:382:3: warning: control reaches end of non-void function [-Wreturn-type]
   }
   ^
```