### PR TITLE
Silence a -Winconsistent-missing-override warning

### DIFF
--- a/target-libretro/libretro.cpp
+++ b/target-libretro/libretro.cpp
@@ -382,7 +382,7 @@ struct Callbacks : Emulator::Interface::Bind {
     return 0;
   }
 
-  void notify(string text) {
+  void notify(string text) override {
     output(RETRO_LOG_ERROR, "%s\n", (const char*)text);
   }
 


### PR DESCRIPTION
Silences the following `-Winconsistent-missing-override` warning with clang.
```
target-libretro/libretro.cpp:385:8: warning: 'notify' overrides a member function
      but is not marked 'override' [-Winconsistent-missing-override]
  void notify(string text) {
       ^
./emulator/interface.hpp:61:18: note: overridden virtual function is here
    virtual void notify(string text) { print(text, "
"); }
                 ^
```