### PR TITLE
out/.gitignore: Don't accidentally commit compiled cores

### DIFF
--- a/out/.gitignore
+++ b/out/.gitignore
@@ -1,1 +1,4 @@
-higan
+*.a
+*.so
+*.dylib
+*.dll


### PR DESCRIPTION
I accidentally commited a compiled core to my own fork with the previous PR before removing it with a force push... This will make it so that doesn't happen again.