### PR TITLE
Silence a -Warray-bounds warning with clang

### DIFF
--- a/target-libretro/libretro.cpp
+++ b/target-libretro/libretro.cpp
@@ -735,7 +735,7 @@ void retro_cheat_set(unsigned index, bool enable, const char *code) {
   char codeCopy[256];
   char *part;
   unsigned addr, data;
-  char addr_str[7], data_str[6];
+  char addr_str[7], data_str[7];
   char *nulstr = (char *)'\0';
 
   if (code == nulstr) return;


### PR DESCRIPTION
Hopefully correctly silences the following warning with clang-4.0.0.
```
clang++ -std=gnu++0x -I. -O3 -fomit-frame-pointer -DSFC_LAGFIX -fPIC -D__LIBRETRO__ -DGIT_VERSION=\"" 29a4357"\" -DPROFILE_ACCURACY -c target-libretro/libretro.cpp -o obj/libretro-accuracy.o
target-libretro/libretro.cpp:750:5: warning: array index 6 is past the end of the
      array (which contains 6 elements) [-Warray-bounds]
    data_str[6]=0;
    ^        ~
target-libretro/libretro.cpp:738:3: note: array 'data_str' declared here
  char addr_str[7], data_str[6];
  ^
1 warning generated.
```
I tested cheats and they seem to work correctly.

Also see https://github.com/libretro/bsnes-libretro/pull/40.