### PR TITLE
make luma=0 darker and randomize initial DSP register state

### DIFF
--- a/sfc/dsp/dsp.cpp
+++ b/sfc/dsp/dsp.cpp
@@ -272,6 +272,15 @@ void DSP::power() {
     voice[i].t_envx_out = 0;
     voice[i].hidden_env = 0;
   }
+  
+  for(unsigned r = 0; r < 0x80; r++) {
+      state.regs[r] = random(0x00);
+  }
+
+  for(unsigned v = 0; v < 8; v++) {
+    state.regs[v * 0x10 + v_envx] = 0;
+    state.regs[v * 0x10 + v_outx] = 0;
+  }
 }
 
 void DSP::reset() {

--- a/sfc/system/video.cpp
+++ b/sfc/system/video.cpp
@@ -33,8 +33,9 @@ void Video::generate_palette(Emulator::Interface::PaletteMode mode) {
       b = image::normalize(b, 5, 8);
     }
 
-    double L = (1.0 + l) / 16.0;
-    if(l == 0) L *= 0.5;
+    //luma=0 is not 100% black; but it's much darker than normal linear scaling
+    //exact effect seems to be analog; requires > 24-bit color depth to represent accurately
+    double L = (1.0 + l) / 16.0 * (l ? 1.0 : 0.25);
     unsigned R = L * image::normalize(r, 8, 16);
     unsigned G = L * image::normalize(g, 8, 16);
     unsigned B = L * image::normalize(b, 8, 16);


### PR DESCRIPTION
fixes hang in Magical Drop before game-over screen in endless mode; makes the black-screen garbage less visible. Backported from upstream v102r18; brings this fork in-line with the bsnes-libretro fork.