### PR TITLE
Use the standard 'rm -f' for the make clean target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,13 +130,11 @@ flags := $(flags) $(foreach o,$(call strupper,$(options)),-D$o)
 
 # targets
 clean:
-	-@$(call delete,obj/*.o)
-	-@$(call delete,obj/*.a)
-	-@$(call delete,obj/*.so)
-	-@$(call delete,obj/*.dylib)
-	-@$(call delete,obj/*.dll)
-	-@$(call delete,*.res)
-	-@$(call delete,*.manifest)
+	rm -f obj/*.o
+	rm -f obj/*.a
+	rm -f out/*.so
+	rm -f out/*.dylib
+	rm -f out/*.dll
 
 help:;
 

--- a/ananke/Makefile
+++ b/ananke/Makefile
@@ -20,9 +20,9 @@ resource: force
 	sourcery resource/resource.bml resource/resource.cpp resource/resource.hpp
 
 clean:
-	-@$(call delete,obj/*.o)
-	-@$(call delete,*.dll)
-	-@$(call delete,*.so)
+	rm -f obj/*.o
+	rm -f *.dll
+	rm -f *.so
 
 install: uninstall
 ifeq ($(platform),windows)

--- a/nall/Makefile
+++ b/nall/Makefile
@@ -31,12 +31,6 @@ ifeq ($(platform),)
   endif
 endif
 
-ifeq ($(platform),windows)
-  delete = del /F /Q $(subst /,\,$1)
-else
-  delete = rm -f $1
-endif
-
 # compiler detection
 ifeq ($(compiler),)
   ifeq ($(platform),windows)


### PR DESCRIPTION
See PR https://github.com/libretro/bsnes-libretro-cplusplus98/pull/18 for the reasoning behind this.

Doing this will also help reduce complexity in the buildbot script.

@Alcaro Would you mind taking a look at this PR and making sure its acceptable? Thanks. :)