### PR TITLE
nall: Allow compiler to be overriden

### DIFF
--- a/nall/Makefile
+++ b/nall/Makefile
@@ -41,7 +41,11 @@ endif
 
 # compiler detection
 ifeq ($(compiler),)
-  ifeq ($(platform),windows)
+  ifneq ($(CXX),)
+    compiler := $(CXX)
+    flags :=
+    link := $(LDFLAGS)
+  else ifeq ($(platform),windows)
     compiler := g++
     flags :=
     link :=


### PR DESCRIPTION
This allows cross compilers to be properly used