### PR TITLE
Support loading MSU-1 roms without markup (.bml) file

### DIFF
--- a/emulator/interface.hpp
+++ b/emulator/interface.hpp
@@ -57,6 +57,7 @@ struct Interface {
     virtual void inputRumble(unsigned, unsigned, unsigned, bool) {}
     virtual unsigned dipSettings(const Markup::Node&) { return 0; }
     virtual string path(unsigned) { return ""; }
+    virtual string filename() { return ""; }
     virtual string server() { return ""; }
     virtual void notify(string text) { print(text, "\n"); }
     virtual unsigned altImplementation(unsigned) { return 0; }
@@ -74,6 +75,7 @@ struct Interface {
   void inputRumble(unsigned port, unsigned device, unsigned input, bool enable) { return bind->inputRumble(port, device, input, enable); }
   unsigned dipSettings(const Markup::Node& node) { return bind->dipSettings(node); }
   string path(unsigned group) { return bind->path(group); }
+  string filename() { return bind->filename(); }
   string server() { return bind->server(); }
   template<typename... Args> void notify(Args&&... args) { return bind->notify({std::forward<Args>(args)...}); }
 

--- a/sfc/cartridge/markup.cpp
+++ b/sfc/cartridge/markup.cpp
@@ -591,17 +591,27 @@ void Cartridge::parse_markup_hsu1(Markup::Node root) {
 }
 
 void Cartridge::parse_markup_msu1(Markup::Node root) {
-  if(root.exists() == false) return;
-  has_msu1 = true;
+  // Read MSU-1 mapping from markup
+  if (root.exists()) {
+    has_msu1 = true;
+    for(auto& node : root) {
+      if(node.name != "map") continue;
 
-  for(auto& node : root) {
-    if(node.name != "map") continue;
-
-    if(node["id"].data == "io") {
-      Mapping m({&MSU1::mmio_read, &msu1}, {&MSU1::mmio_write, &msu1});
-      parse_markup_map(m, node);
-      mapping.append(m);
+      if(node["id"].data == "io") {
+        Mapping m({&MSU1::mmio_read, &msu1}, {&MSU1::mmio_write, &msu1});
+        parse_markup_map(m, node);
+        mapping.append(m);
+      }
     }
+    return;
+  }
+
+  // Use default mapping if .msu file exists
+  if (file::exists({interface->path(ID::SuperFamicom), nall::basename(interface->filename()), ".msu"})) {
+    has_msu1 = true;
+    Mapping m({&MSU1::mmio_read, &msu1}, {&MSU1::mmio_write, &msu1});
+    m.addr = "00-3f,80-bf:2000-2007";
+    mapping.append(m);
   }
 }
 

--- a/sfc/chip/msu1/msu1.cpp
+++ b/sfc/chip/msu1/msu1.cpp
@@ -99,8 +99,13 @@ void MSU1::data_open() {
 
 void MSU1::audio_open() {
   if(audiofile.open()) audiofile.close();
+  string name = {interface->path(ID::SuperFamicom), nall::basename(interface->filename()), "-", mmio.audio_track, ".pcm"};
+  if(audiofile.open(name, file::mode::read)) {
+    audiofile.seek(mmio.audio_offset);
+    return;
+  }
   auto document = Markup::Document(cartridge.information.markup.cartridge);
-  string name = {"track-", mmio.audio_track, ".pcm"};
+  name = {"track-", mmio.audio_track, ".pcm"};
   for(auto track : document.find("cartridge/msu1/track")) {
     if(numeral(track["number"].data) != mmio.audio_track) continue;
     name = track["name"].data;

--- a/target-libretro/libretro.cpp
+++ b/target-libretro/libretro.cpp
@@ -106,6 +106,7 @@ struct Callbacks : Emulator::Interface::Bind {
 
   Emulator::Interface *iface;
   string basename;
+  string rom_filename;
 
   bool input_polled;
 
@@ -398,6 +399,10 @@ struct Callbacks : Emulator::Interface::Bind {
 
   string path(unsigned) override {
     return string(basename);
+  }
+
+  string filename() override {
+    return string(rom_filename);
   }
 
   uint32_t videoColor(unsigned, uint16_t, uint16_t r, uint16_t g, uint16_t b) override {
@@ -1133,6 +1138,7 @@ bool retro_load_game(const struct retro_game_info *info) {
   if (info->path) {
     core_bind.load_request_error = false;
     core_bind.basename = info->path;
+    core_bind.rom_filename = nall::notdir(info->path);
 
     char *posix_slash = (char*)strrchr(core_bind.basename, '/');
     char *win_slash = (char*)strrchr(core_bind.basename, '\\');
@@ -1180,6 +1186,7 @@ bool retro_load_game_special(unsigned game_type,
   if (info[0].path) {
     core_bind.load_request_error = false;
     core_bind.basename = info[0].path;
+    core_bind.rom_filename = nall::notdir(info->path);
 
     char *posix_slash = (char*)strrchr(core_bind.basename, '/');
     char *win_slash = (char*)strrchr(core_bind.basename, '\\');


### PR DESCRIPTION
Requires a _romname_.msu file as well as matching pcm files (_romname_-1.pcm etc.), same as newer bsnes/snes9x.